### PR TITLE
only look at open prs when checking for push

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -71,6 +71,7 @@ So I'd need to tweak that.
 We also want to run tests on PR merge (unless we get very smart and know that they do not need to be rerun see experiment 3).
 2. When opening a PR the commit is not yet part of a PR.
 So duplicate runs occur.
+Anything we can do that would work for both local branch and fork?
 3. In my testing I got occassional 403 errors, indicating rate limiting.
 +
 > You have exceeded a secondary rate limit. Please wait a few minutes before you try again.

--- a/script/ci_create_check_vars.clj
+++ b/script/ci_create_check_vars.clj
@@ -2,10 +2,10 @@
          '[cheshire.core :as json]
          '[clojure.string :as str])
 
-(defn is-pushing-in-pr [{:keys [commit-sha event-name repo]}]
+(defn is-pushing-in-open-pr [{:keys [commit-sha event-name repo]}]
   (let [prs (-> (t/shell {:out :string
                           :extra-env {"PAGER" "cat"}}
-                         "gh search prs" commit-sha "--json" "number" "--repo" repo)
+                         "gh search prs" commit-sha "--state" "open" "--json" "number" "--repo" repo)
                 :out
                 (json/parse-string true)
                 doall)
@@ -25,7 +25,7 @@
         is-version-tag (str/starts-with? ref "ref/tags/v")
         run-tests (or is-version-tag
                       (and (not is-publish-commit)
-                           (not (is-pushing-in-pr github))))]
+                           (not (is-pushing-in-open-pr github))))]
     (println "inputs:" (pr-str github))
     (println "is-publish-commit" is-publish-commit)
     (println "is-version-tag" is-version-tag)


### PR DESCRIPTION
We'll see if enables test run on merge of a PR.
The commit sha is part of a PR when it is being merged. Gonna assume the PR is closed by GHA prior to executing PR merge.